### PR TITLE
UPD: Make package.json cross compatible

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,8 @@
 # MENPAL-T
 MongoDB + Express + Node + Prisma + AWS Lambda + TypeScript API Template
+
+### Note:
+
+For Windows, use the `*-win` scripts.
+
+For example, instead of `pnpm dev`, use `pnpm dev-win`

--- a/package.json
+++ b/package.json
@@ -8,9 +8,13 @@
   },
   "scripts": {
     "start": "pnpm build && sls offline --httpPort 5000",
+    "start-win": "pnpm build-win && sls offline --httpPort 5000",
     "dev": "nodemon -e ts --exec 'pnpm run start'",
+    "dev-win": "nodemon -e ts --exec pnpm run start-win",
     "build": "pnpm compile && pnpm esbuild && rm -rf $npm_package_config_build_dir",
+    "build-win": "pnpm compile && pnpm esbuild-win && del /s /q /f %npm_package_config_build_dir% 1>null",
     "esbuild": "esbuild $npm_package_config_build_dir/$npm_package_config_build_entry --bundle --platform=node --target=node18 --outfile=$npm_package_config_dist_dir/$npm_package_config_dist_outfile --minify",
+    "esbuild-win": "esbuild %npm_package_config_build_dir%/%npm_package_config_build_entry% --bundle --platform=node --target=node18 --outfile=%npm_package_config_dist_dir%/%npm_package_config_dist_outfile% --minify",
     "compile": "tsc",
     "lint": "eslint . --ext .ts --fix",
     "pretty": "pnpm prettier --write .",


### PR DESCRIPTION
By default, `npm` runs its scripts inside CMD shell (can be configured to use different shell by setting the `script-shell` npm var. See [this](https://stackoverflow.com/a/46006249/12982627).

Unlike POSIX Shells, in CMD, variables are substituted using `%%` instead of `$`.

This commit provides a build script for running it in windows(CMD).